### PR TITLE
Add local: true attribute to forms to not render them using AJAX

### DIFF
--- a/app/views/reports/edit.html.slim
+++ b/app/views/reports/edit.html.slim
@@ -1,7 +1,7 @@
 h1= report.title
 
 = render 'shared/errors', resource: report
-= form_with model: report do |f|
+= form_with model: report, local: true do |f|
   = f.label :title
   = f.text_field :title
 

--- a/app/views/reports/new.html.slim
+++ b/app/views/reports/new.html.slim
@@ -1,7 +1,7 @@
 h1= t('.headline')
 
 = render 'shared/errors', resource: report
-= form_with model: report do |f|
+= form_with model: report, local: true do |f|
   = f.label :title
   = f.text_field :title
 

--- a/app/views/temperature_reports/new.html.slim
+++ b/app/views/temperature_reports/new.html.slim
@@ -1,7 +1,7 @@
 h1= t('.headline')
 
 = render 'shared/errors', resource: temperature_report
-= form_with model: [report, temperature_report] do |f|
+= form_with model: [report, temperature_report], local: true do |f|
   = f.label :title
   = f.text_field :title
 


### PR DESCRIPTION
The following functionality were implemented in this pull request:
* `local: true` attribute was added to all forms to avoid using AJAX, while rendering them.